### PR TITLE
initialize as objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,8 @@ async function main() {
 	getID("discover-form").onsubmit = async (e)=>{
 		e.preventDefault();
 		queue = [];
-		knownUsers = [];
-		loadedUsers = [];
+		knownUsers = {};
+		loadedUsers = {};
 		status = {};
 		getID("user-count").innerHTML = '0';
 		getID("userlist").innerHTML = '';


### PR DESCRIPTION
It worked as it was, but this is easier to debug.

to match the initial:

```
let knownUsers = {};
let loadedUsers = {};
```